### PR TITLE
✨ Focus SCM input box when commit message created

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.executeCommand('workbench.view.scm');
 
         createCommitMessage({ emoji, message, description, task }, uri);
+
+        vscode.commands.executeCommand('workbench.scm.focus');
     });
 
     context.subscriptions.push(disposable);


### PR DESCRIPTION
Wasn't easy to find how to do it, but finally I found it in this issue https://github.com/microsoft/vscode/issues/119904. Focusing input box when commit message is created is quite convenient from two reason:

1) I can immediately commit with Cmd+Enter when I select ticket reference from the list thus commit message is complete
2) I can immediately write referenced ticket number when I'm not able to select it in the list and choose a "Fill in custom number" option

Please merge and release soon, it's gonna make me sooo happy that I don't need to focus manually every time 🙏 😄  